### PR TITLE
Use a Alpine and multi stage builds to lower image footprint

### DIFF
--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -1,16 +1,24 @@
 ## -*- docker-image-name: "spotify/bigtable-emulator" -*-
 
-FROM golang:1.7
+FROM golang:1.9-alpine3.6 as builder
 MAINTAINER Robert Gruener "robertg@spotify.com"
 
-# Install netcat
-RUN apt-get update
-RUN apt-get install -y netcat
+# Get necessary dependency to run 'go get'
+RUN apk update && apk upgrade && apk add git
 
 # Get bigtable go package
 RUN go get -u cloud.google.com/go/bigtable
 
 ADD bigtable-server.go /go/bin/bigtable-server.go
 RUN go build /go/bin/bigtable-server.go
-ENTRYPOINT ["/go/bigtable-server"]
+
+
+FROM alpine:3.6
+
+# Get netcat
+RUN apk update && apk upgrade && apk add --no-cache netcat-openbsd
+
+COPY --from=builder /go/bigtable-server /
+
+ENTRYPOINT ["/bigtable-server"]
 EXPOSE 8080


### PR DESCRIPTION
## Problem

The image is currently quite large (~ 350MB) and so can be taxing for build systems.

## Solution

Use a combination of Alpine and multistage build in order to reduce the resulting image. The multistage allows to not worry about build time dependencies and just copy over the executable we are interested in.

## Result

An image with the same features as before, but around 17 MB.

@rgruener 