### PR TITLE
Column families and other small improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ To run locally use the command:
 docker run -it -p 8080:8080 spotify/bigtable-emulator:latest
 ```
 
+You can specify tables and column families to be created at startup by using the `-cf` switch. The format is a comma separated list of `<instance>.<table>.<column family>`. Ex:
+```
+docker run -it -p 8080:8080 spotify/bigtable-emulator:latest -cf dev.records.data,dev.records.meta
+```
+
 ## Using with the Google Cloud Bigtable client
 
 To use with the [Cloud Bigtable Client](https://github.com/GoogleCloudPlatform/cloud-bigtable-client) you need to

--- a/bigtable-server.go
+++ b/bigtable-server.go
@@ -18,24 +18,103 @@
 package main
 
 import (
+        "context"
         "fmt"
         "os"
         "os/signal"
         "syscall"
         "cloud.google.com/go/bigtable/bttest"
+        "cloud.google.com/go/bigtable"
+        "google.golang.org/grpc"
+        "strings"
+        "google.golang.org/api/option"
+        "flag"
+        "errors"
 )
 
-
 func main() {
+        cfs := flag.String("cf", "", "Optional: the column families to create at startup. Format: a series of <instance>.<table>.<column familiy>, comma separated. Ex: \n          docker run -d spotify/bigtable-emulator -cf dev.records.data,dev.records.metadata")
+        flag.Parse()
+
         srv, err := bttest.NewServer("0.0.0.0:8080")
         if err != nil {
-                fmt.Printf("Error!")
+                fmt.Fprintf(os.Stderr, "Error starting the server: %v\n", err)
+                return
         }
         defer srv.Close()
+
+        if err = createColumnFamiliies(*cfs); err != nil {
+                fmt.Fprintf(os.Stderr, "Error creating the column familiies: %v\n", err)
+                return
+        }
+
         sigs := make(chan os.Signal, 1)
         signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
 
-        fmt.Printf("bttest.Server running on %s", srv.Addr)
+        fmt.Printf("bttest.Server running on %s\n", srv.Addr)
         <-sigs
         fmt.Println("done")
+}
+
+func createColumnFamiliies(specifications string) error {
+        if specifications == "" {
+                return nil
+        }
+
+        ctx := context.Background()
+        conn, err := grpc.Dial("localhost:8080", grpc.WithInsecure())
+        if err != nil {
+                return fmt.Errorf("could not connect to bigtable emulator: %v", err)
+        }
+
+        for _, specification := range strings.Split(specifications, ",") {
+                specificationElements := strings.Split(specification, ".")
+                if len(specificationElements) != 3 {
+                        return errors.New("format of column family to create is <instance>.<table>.<column family>")
+                }
+
+                instance := specificationElements[0]
+                table := specificationElements[1]
+                columnFamily := specificationElements[2]
+
+                client, err := bigtable.NewAdminClient(ctx, "dev", instance, option.WithGRPCConn(conn))
+                if err != nil {
+                        return fmt.Errorf("failed to create admin client: %v", err)
+                }
+
+                tables, err := client.Tables(ctx)
+                if !tableExists(tables, table) {
+                        if err = client.CreateTable(ctx, table); err != nil {
+                                return err
+                        }
+                }
+
+                tableInfo, err := client.TableInfo(ctx, table)
+                if !columnFamilyExists(tableInfo.FamilyInfos, columnFamily) {
+                        fmt.Printf("creating %v.%v.%v column family\n", instance, table, columnFamily)
+                        if err := client.CreateColumnFamily(ctx, table, columnFamily); err != nil {
+                                return err
+                        }
+                }
+        }
+
+        return nil
+}
+
+func tableExists(tables []string, table string) bool {
+        for _, item := range tables {
+                if item == table {
+                        return true
+                }
+        }
+        return false
+}
+
+func columnFamilyExists(columnFamilies []bigtable.FamilyInfo, columnFamily string) bool {
+        for _, family := range columnFamilies {
+                if family.Name == columnFamily {
+                        return true
+                }
+        }
+        return false
 }

--- a/runtest
+++ b/runtest
@@ -4,11 +4,13 @@ echo -n "Checking that bigtable is up and running ... "
 
 RUN_NAME=$(head /dev/urandom | LC_ALL=C tr -dc A-Za-z0-9 | head -c 8)
 
-$DOCKER run -d --name="${RUN_NAME}" $1;
+$DOCKER run -d --name="${RUN_NAME}" $1 -cf dev.records.data,dev.records.meta,dev.records_by_secondary.data;
 sleep 5
 $DOCKER exec -ti $RUN_NAME nc -w2 -z localhost 8080 
 EXIT_STATUS=$?
+$DOCKER logs --details $RUN_NAME
 $DOCKER kill $RUN_NAME
+$DOCKER rm $RUN_NAME
 
 if [[ $EXIT_STATUS -eq 0 ]]
 then


### PR DESCRIPTION
## Problem

This docker image is useful for integration tests. However, the first thing every test must do is create the necessary tables and column families. It would be very convenient to be able to specify which tables and column families are necessary at startup, so no special build or test logic is required.

## Solution

Add an optional `-cf` flag allowing to specify which tables and column families to be created at startup.

## Result

The user can just specify what needs to be created at startup:

```
docker run -d -p 8080:8080 spotify/bigtable-emulator  -cf dev.records.data,dev.records.meta
```

This would create `data` and `meta` column families in the `records` new table in the `dev` instance.

This PR is also adding small improvements:

- the log line `bttest.Server running on [::]:8080` appear at startup so users can wait for this line to appear in `docker logs` instead of waiting an arbitrary number of seconds after launching the server.
- the makefile is removing the test container after the test in order to not pollute Docker.
- when an error occur, the details are printed in the standard error stream.

@rgruener 